### PR TITLE
Rename project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,7 +631,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    files-preview-python-api generates images based on .msg files.
+    msg-previewer generates images based on .msg files.
     Copyright (C) 2024  enthus GmbH
 
     This program is free software: you can redistribute it and/or modify
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    files-preview-python-api  Copyright (C) 2024  enthus GmbH
+    msg-previewer  Copyright (C) 2024  enthus GmbH
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
This pull request includes updates to the `LICENSE` file to reflect the renaming of the project from `files-preview-python-api` to `msg-previewer`.

Project renaming:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L634-R634): Updated the project name from `files-preview-python-api` to `msg-previewer` in the copyright notice.
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L655-R655): Changed the project name in the terminal interaction notice to `msg-previewer`.